### PR TITLE
callback/payload data support

### DIFF
--- a/lib/telegram_bot.js
+++ b/lib/telegram_bot.js
@@ -76,12 +76,12 @@ class TelegramBot extends BaseBot {
     this.app.post('*', (req, res) => {
       this.__formatUpdate(req.body)
 
-      .then((update) => {
-        this.__emitUpdate(update);
-      }, (err) => {
-        err.message = `Error in __formatUpdate "${err.message}". Please report this.`;
-        this.emit('error', err);
-      });
+        .then((update) => {
+          this.__emitUpdate(update);
+        }, (err) => {
+          err.message = `Error in __formatUpdate "${err.message}". Please report this.`;
+          this.emit('error', err);
+        });
 
       // just letting telegram know we got the update
       res.sendStatus(200);
@@ -90,33 +90,59 @@ class TelegramBot extends BaseBot {
 
   __formatUpdate(rawUpdate) {
     const promise = new Promise((resolve) => {
-      const update = {
-        raw: rawUpdate,
-        sender: {
-          id: rawUpdate.message.from.id,
-        },
-        recipient: {
-          id: this.id,
-        },
-        timestamp: rawUpdate.message.date * 1000,
-        message: {
-          mid: rawUpdate.update_id,
-          seq: rawUpdate.message.message_id,
-        },
-      };
+      let update = {};
 
-      if (rawUpdate.message.text !== undefined) {
-        update.message.text = rawUpdate.message.text;
+      // if part to receive the quick reply response - when using payload
+      // else part to get the normal messages + normal quick replies
+      if (rawUpdate.callback_query) {
+        update = {
+          raw: rawUpdate,
+          sender: {
+            id: rawUpdate.callback_query.from.id,
+          },
+          recipient: {
+            id: rawUpdate.callback_query.message.from.id,
+          },
+          timestamp: rawUpdate.callback_query.message.date * 1000,
+          message: {
+            mid: rawUpdate.update_id,
+            seq: rawUpdate.callback_query.message.message_id,
+          },
+        };
+      } else {
+        update = {
+          raw: rawUpdate,
+          sender: {
+            id: rawUpdate.message.from.id,
+          },
+          recipient: {
+            id: this.id,
+          },
+          timestamp: rawUpdate.message.date * 1000,
+          message: {
+            mid: rawUpdate.update_id,
+            seq: rawUpdate.message.message_id,
+          },
+        };
       }
 
-      this.__getAttachments(rawUpdate)
-
-      .then((attachments) => {
-        if (attachments.length > 0) {
-          update.message.attachments = attachments;
+      // get the message or callback data from response
+      if (rawUpdate.callback_query) {
+        update.message.text = rawUpdate.callback_query.data;
+      } else if (rawUpdate.message) {
+        if (rawUpdate.message.text !== undefined) {
+          update.message.text = rawUpdate.message.text;
         }
-        resolve(update);
-      });
+      }
+
+
+      this.__getAttachments(rawUpdate)
+        .then((attachments) => {
+          if (attachments.length > 0) {
+            update.message.attachments = attachments;
+          }
+          resolve(update);
+        });
     });
 
     return promise;
@@ -144,77 +170,85 @@ class TelegramBot extends BaseBot {
     return Promise.all(fileIdsInfo.map(
       fileIdInfo => this.__getAttachment(fileIdInfo.id, fileIdInfo.type))
     )
-    .then(attachments => attachments.concat(locationAttachment));
+      .then(attachments => attachments.concat(locationAttachment));
   }
 
   __getAttachmentsInfo(rawUpdate) {
     const fileIdsInfo = [];
 
-    if (rawUpdate.message.audio !== undefined) {
-      fileIdsInfo.push({
-        id: rawUpdate.message.audio.file_id,
-        type: 'audio',
-      });
-    }
-    if (rawUpdate.message.voice !== undefined) {
-      // messenger only has audio
-      fileIdsInfo.push({
-        id: rawUpdate.message.voice.file_id,
-        type: 'audio',
-      });
-    }
-    if (rawUpdate.message.document !== undefined) {
-      fileIdsInfo.push({
-        id: rawUpdate.message.document.file_id,
-        type: 'file',
-      });
-    }
-    if (rawUpdate.message.photo !== undefined) {
-      // telegram returns array of PhotoSize, => we take last (largest one).
-      const photoSizeArray = rawUpdate.message.photo;
-      const fileId = photoSizeArray[photoSizeArray.length - 1].file_id;
-      fileIdsInfo.push({
-        id: fileId,
-        type: 'image',
-      });
-    }
-    if (rawUpdate.message.sticker !== undefined) {
-      // messenger only has image
-      fileIdsInfo.push({
-        id: rawUpdate.message.sticker.file_id,
-        type: 'image',
-      });
-    }
-    if (rawUpdate.message.video !== undefined) {
-      fileIdsInfo.push({
-        id: rawUpdate.message.video.file_id,
-        type: 'video',
-      });
+    // if rawUpdate data doesn't contain any callback data, then only process it
+    if (rawUpdate.message) {
+
+      if (rawUpdate.message.audio !== undefined) {
+        fileIdsInfo.push({
+          id: rawUpdate.message.audio.file_id,
+          type: 'audio',
+        });
+      }
+      if (rawUpdate.message.voice !== undefined) {
+        // messenger only has audio
+        fileIdsInfo.push({
+          id: rawUpdate.message.voice.file_id,
+          type: 'audio',
+        });
+      }
+      if (rawUpdate.message.document !== undefined) {
+        fileIdsInfo.push({
+          id: rawUpdate.message.document.file_id,
+          type: 'file',
+        });
+      }
+      if (rawUpdate.message.photo !== undefined) {
+        // telegram returns array of PhotoSize, => we take last (largest one).
+        const photoSizeArray = rawUpdate.message.photo;
+        const fileId = photoSizeArray[photoSizeArray.length - 1].file_id;
+        fileIdsInfo.push({
+          id: fileId,
+          type: 'image',
+        });
+      }
+      if (rawUpdate.message.sticker !== undefined) {
+        // messenger only has image
+        fileIdsInfo.push({
+          id: rawUpdate.message.sticker.file_id,
+          type: 'image',
+        });
+      }
+      if (rawUpdate.message.video !== undefined) {
+        fileIdsInfo.push({
+          id: rawUpdate.message.video.file_id,
+          type: 'video',
+        });
+      }
     }
 
     return fileIdsInfo;
   }
 
   __getLocationAttachment(rawUpdate) {
-    const location = rawUpdate.message.location;
-    const venue = rawUpdate.message.venue;
-    if (location) {
-      const lat = location.latitude;
-      const long = location.longitude;
-      const locationAttachment = {};
-      locationAttachment.type = 'location';
-      locationAttachment.title = 'Pinned Location';
-      locationAttachment.url = `https://maps.google.com/?q=${lat},${long}`;
-      locationAttachment.payload = {
-        coordinates: {
-          lat,
-          long,
-        },
-      };
-      if (venue) {
-        locationAttachment.title = venue.title;
+    // if rawUpdate data doesn't contain any callback data, then only process it
+    if (rawUpdate.message) {
+
+      const location = rawUpdate.message.location;
+      const venue = rawUpdate.message.venue;
+      if (location) {
+        const lat = location.latitude;
+        const long = location.longitude;
+        const locationAttachment = {};
+        locationAttachment.type = 'location';
+        locationAttachment.title = 'Pinned Location';
+        locationAttachment.url = `https://maps.google.com/?q=${lat},${long}`;
+        locationAttachment.payload = {
+          coordinates: {
+            lat,
+            long,
+          },
+        };
+        if (venue) {
+          locationAttachment.title = venue.title;
+        }
+        return [locationAttachment];
       }
-      return [locationAttachment];
     }
 
     return null;
@@ -223,16 +257,16 @@ class TelegramBot extends BaseBot {
   __getAttachment(fileId, type) {
     return this._getFile(fileId)
 
-    .then((result) => {
-      const attachment = {
-        type,
-        payload: {
-          url: `${this.baseFileUrl}/${result.file_path}`,
-        },
-      };
+      .then((result) => {
+        const attachment = {
+          type,
+          payload: {
+            url: `${this.baseFileUrl}/${result.file_path}`,
+          },
+        };
 
-      return attachment;
-    });
+        return attachment;
+      });
   }
 
   _getFile(fileId) {
@@ -246,7 +280,7 @@ class TelegramBot extends BaseBot {
       body: data,
       json: true,
     })
-    .then(body => body.result);
+      .then(body => body.result);
   }
 
   __formatOutgoingMessage(message) {
@@ -289,8 +323,8 @@ class TelegramBot extends BaseBot {
 
   __sendMessage(rawMessage) {
     const endPoint = rawMessage.action
-    ? 'sendChatAction'
-    : 'sendMessage';
+      ? 'sendChatAction'
+      : 'sendMessage';
 
     const url = `${this.baseUrl}/${endPoint}`;
 


### PR DESCRIPTION
**Scenario:** I am using telegram for the campaign purpose, where I am sending the quick options (with payload data) to telegram chats with my custom campaign api. when a user click on the appropriate option, I'll get the response data from telegram and based on the payload data from response, I'll navigate the user to a specific node in my predefined bot flow.

**Problem:** When a user clicks on the option, botmaster is unable to process the incoming data (cause it's format is different because of payload data) and hence, my bot failing in navigating the user to a specific node in my bot flow.

This build is not affecting any existing functionalities, plus it is extending the telegram bot capabilities to consume the callback/payload data from **_inline_keyboard_** event.